### PR TITLE
Version 3.0 — SVG icons, edit mode, UX improvements, store listing

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,0 +1,45 @@
+# Privacy Policy — Power Platform Environment Colored Banner
+
+*Last updated: 2026-06-20*
+*Author: Karol Kozłowski | [CitDev](https://citdev.pl/)*
+
+---
+
+## What data does this extension collect?
+
+**None.** Power Platform Environment Colored Banner does not collect, record, transmit, or share any personal data or usage information of any kind.
+
+## What data does this extension store?
+
+The extension stores only the configuration data that **you explicitly enter** in the settings page:
+
+| Data | Where it is stored |
+|---|---|
+| Environment ID, background color, environment type, description | `chrome.storage.sync` — your browser's built-in sync storage |
+| SVG icon files uploaded by you | `chrome.storage.local` — your browser's local storage |
+
+All data remains in your browser. `chrome.storage.sync` may be synchronized between your own signed-in devices by your browser's built-in sync mechanism (e.g. Chrome Sync or Edge Sync) — this is a standard browser feature entirely outside the control of this extension.
+
+## Does this extension access page content?
+
+No. The content script injected into Power Platform pages reads only `window.location.href` (the current URL) in order to extract the environment ID from the URL path. It does not read, copy, or interact with any page content, user input, form data, or other information on the page.
+
+## Does this extension communicate with external servers?
+
+No. The extension makes no network requests of any kind. There are no analytics, telemetry, crash reports, advertisements, or third-party services involved.
+
+## Does this extension use remote code?
+
+No. All code is bundled within the extension itself. No scripts are loaded from external sources at runtime.
+
+## Third-party services
+
+The settings page loads **Bootstrap CSS** and **Bootstrap Icons** stylesheets from the [jsDelivr](https://www.jsdelivr.com/) CDN for visual styling only. These are standard, widely-used open-source libraries. No JavaScript is loaded from external sources. Please refer to jsDelivr's own privacy policy if you have concerns about CDN requests.
+
+## Changes to this policy
+
+If this policy is updated, the *Last updated* date at the top of this file will change. The history of changes is available in this repository's commit log.
+
+## Contact
+
+For questions or concerns, contact the author at [citdev.pl](https://citdev.pl/).

--- a/README.md
+++ b/README.md
@@ -1,14 +1,111 @@
-# Power-Platform-Environment-Colored-Banner
-**Power Platform Environment Colored Banner** is a browser extension designed for Microsoft Power Platform users, particularly those working with Power Apps, that helps identify the current environment (e.g., Production, Sandbox, Developer) by displaying a customizable banner on the page. This tool minimizes errors by ensuring you know exactly where you’re working.
+# Power Platform Environment Colored Banner
 
-## Why Use This Extension?
-When working across multiple environments (production, sandbox, testing, etc.), it’s easy to lose track and accidentally perform actions in the wrong environment. Power Platform Environment Colored Banner addresses this issue by displaying a colored banner at the top of the page, indicating the type of environment and optional description. At a glance, you know where you are, helping prevent unwanted modifications.
+> Browser extension for Microsoft Power Platform — instantly know which environment you're working in.
 
-## How to Use This Extension?
-After installing the extension, click on its icon. Then, on the newly opened settings page, fill out the form by entering the environment ID (GUID). You can find this ID directly in the URL. Next, choose a background color and environment type, and optionally, add a description. Once the environment is added, it will appear in the list below the form. You can update the environment’s settings at any time by adding it again with the same ID (the extension will overwrite the existing entry if the ID is already on the list). You can also delete any added entry whenever needed.
+---
 
-### Settings:
-![](https://citdev.pl/blog/wp-content/uploads/2024/11/image.png)
+## English
 
-### Banner:
-![](https://citdev.pl/blog/wp-content/uploads/2024/11/image-5.png)
+**Power Platform Environment Colored Banner** is a browser extension for users working with Microsoft Power Platform (Power Apps, Power Automate, Power Pages, Admin Center). It displays a slim, color-coded banner at the top of every Power Platform page so you always know which environment you're in — production, sandbox, testing, or any custom type you define.
+
+### Why use it?
+
+Working across multiple environments (production, sandbox, UAT, developer…) makes it dangerously easy to perform actions in the wrong one. This extension eliminates that risk with a permanent, color-coded visual indicator at the top of the page, showing the environment type, a custom description, and an optional SVG icon.
+
+### Features
+
+- **Colored banner** — fixed 18 px strip at the top of every supported page; background color fully customizable per environment
+- **Three-section layout** — environment type on the left, description centered, SVG icon on the right
+- **Automatic text contrast** — banner text color (black or white) is calculated automatically based on the background luminance
+- **SVG icon per environment** — upload any SVG file as a visual identifier; icon color adapts to the banner contrast color
+- **Edit environments** — click the pencil icon in the list to pre-fill the form and update color, type, description or icon without re-entering the ID
+- **Custom environment type** — besides the seven presets (Production, Default, Sandbox, Trial, Developer, UAT, Testing) you can define any free-form type name
+- **Filter table** — live search above the environment list filters by ID, type or description
+- **Toast notifications** — non-blocking success/warning messages replace native `alert()` dialogs; delete confirmation uses a modal instead of `confirm()`
+- **Case-insensitive matching** — environment IDs in URLs and in saved settings are compared case-insensitively, so mixed-case GUIDs always match
+- **Settings sync** — environment metadata is stored in `chrome.storage.sync` (synchronized across devices); SVG icons are stored in `chrome.storage.local`
+- **Optimized URL monitoring** — uses `MutationObserver` (throttled via `requestAnimationFrame`) plus `popstate` / `hashchange` events; no polling interval
+
+### Supported pages
+
+| Service | URL |
+|---|---|
+| Power Apps | `make.powerapps.com` |
+| Power Automate | `make.powerautomate.com` |
+| Power Pages | `make.powerpages.microsoft.com` |
+| Power Platform Admin Center | `admin.powerplatform.microsoft.com` |
+| Power Apps (US Gov) | `make.gov.powerapps.us` |
+| Power Automate (US Gov) | `make.gov.powerautomate.us` |
+| Power Apps Preview | `make.preview.powerapps.com` |
+| Power Automate Preview | `make.preview.powerautomate.com` |
+
+### How to use
+
+1. Install the extension and click its icon to open the settings page.
+2. Enter the **Environment ID** (GUID) — copy it from the URL: `make.powerapps.com/environments/`**`<ID>`**`/`
+3. Pick a **background color** using the color picker.
+4. Select an **environment type** (or choose *Custom…* and type your own).
+5. Optionally add a **description** and upload an **SVG icon**.
+6. Click **Save** — the environment appears in the list below.
+7. To edit an existing entry, click the **pencil** button in the row and update the form. Click **Update** to apply.
+8. To remove an entry, click the **trash** button and confirm in the modal.
+
+### Settings page
+
+![Settings page](https://citdev.pl/blog/wp-content/uploads/2024/11/image.png)
+
+### Banner
+
+![Banner](https://citdev.pl/blog/wp-content/uploads/2024/11/image-5.png)
+
+---
+
+## Polski
+
+**Power Platform Environment Colored Banner** to rozszerzenie do przeglądarki dla użytkowników Microsoft Power Platform (Power Apps, Power Automate, Power Pages, Admin Center). Na każdej stronie Power Platform wyświetla wąski, kolorowy pasek u góry ekranu — dzięki niemu zawsze wiesz, w jakim środowisku pracujesz.
+
+### Po co to rozszerzenie?
+
+Praca w wielu środowiskach (produkcja, sandbox, testy, deweloper…) łatwo prowadzi do pomyłek — przypadkowe działanie w złym środowisku może mieć poważne konsekwencje. Rozszerzenie eliminuje to ryzyko, wyświetlając stały, kolorowy wskaźnik u góry strony z typem środowiska, opcjonalnym opisem i ikoną.
+
+### Funkcje
+
+- **Kolorowy pasek** — stały pasek o wysokości 18 px u góry każdej obsługiwanej strony; kolor tła konfigurowalny osobno dla każdego środowiska
+- **Układ trójkolumnowy** — typ środowiska po lewej, opis na środku, ikona SVG po prawej
+- **Automatyczny kontrast tekstu** — kolor tekstu (czarny lub biały) dobierany automatycznie na podstawie luminancji tła
+- **Ikona SVG dla środowiska** — wgraj dowolny plik SVG jako wizualny identyfikator; kolor ikony dostosowuje się do koloru kontrastu paska
+- **Edycja środowisk** — kliknij ikonę ołówka w tabeli, aby wypełnić formularz danymi wybranego środowiska i zaktualizować kolor, typ, opis lub ikonę bez ponownego wpisywania ID
+- **Własny typ środowiska** — oprócz siedmiu predefiniowanych typów (Production, Default, Sandbox, Trial, Developer, UAT, Testing) możesz wpisać dowolną własną nazwę
+- **Filtrowanie tabeli** — pole wyszukiwania nad listą środowisk filtruje na żywo po ID, typie i opisie
+- **Powiadomienia toast** — nienachalne komunikaty sukcesu/ostrzeżenia zastępują natywne `alert()`; potwierdzenie usunięcia wyświetlane jest w modalu zamiast `confirm()`
+- **Dopasowanie bez względu na wielkość liter** — ID środowisk w adresach URL i w zapisanych ustawieniach porównywane są bez rozróżniania wielkości liter
+- **Synchronizacja ustawień** — dane środowisk przechowywane w `chrome.storage.sync` (synchronizowane między urządzeniami); ikony SVG w `chrome.storage.local`
+- **Optymalne monitorowanie URL** — `MutationObserver` z throttlingiem przez `requestAnimationFrame` oraz zdarzenia `popstate` / `hashchange`; brak odpytywania co sekundę
+
+### Obsługiwane strony
+
+| Usługa | Adres |
+|---|---|
+| Power Apps | `make.powerapps.com` |
+| Power Automate | `make.powerautomate.com` |
+| Power Pages | `make.powerpages.microsoft.com` |
+| Power Platform Admin Center | `admin.powerplatform.microsoft.com` |
+| Power Apps (US Gov) | `make.gov.powerapps.us` |
+| Power Automate (US Gov) | `make.gov.powerautomate.us` |
+| Power Apps Preview | `make.preview.powerapps.com` |
+| Power Automate Preview | `make.preview.powerautomate.com` |
+
+### Jak używać
+
+1. Zainstaluj rozszerzenie i kliknij jego ikonę, aby otworzyć stronę ustawień.
+2. Wpisz **Environment ID** (GUID) — skopiuj go z adresu URL: `make.powerapps.com/environments/`**`<ID>`**`/`
+3. Wybierz **kolor tła** za pomocą selektora kolorów.
+4. Wybierz **typ środowiska** (lub „Custom…" i wpisz własną nazwę).
+5. Opcjonalnie dodaj **opis** i wgraj **ikonę SVG**.
+6. Kliknij **Save** — środowisko pojawi się na liście poniżej.
+7. Aby edytować istniejący wpis, kliknij przycisk **ołówka** w wierszu i zaktualizuj formularz. Kliknij **Update**, aby zatwierdzić.
+8. Aby usunąć wpis, kliknij przycisk **kosza** i potwierdź w modalu.
+
+---
+
+*Author: Karol Kozłowski | [CitDev](https://citdev.pl/)*

--- a/STORE_LISTING.md
+++ b/STORE_LISTING.md
@@ -1,0 +1,195 @@
+# Store Listing — Power Platform Environment Colored Banner
+
+Information required to publish the extension in the **Chrome Web Store** (Google) and **Microsoft Edge Add-ons** store.
+
+---
+
+## General (shared by both stores)
+
+### Extension name
+```
+Power Platform Environment Colored Banner
+```
+
+### Short description
+*(Chrome: max 132 characters · Edge: max 250 characters)*
+```
+Displays a color-coded banner on Power Platform pages so you always know which environment (Production, Sandbox, etc.) you're working in.
+```
+
+### Detailed description
+*(Chrome: max 16,000 characters · Edge: max 10,000 characters)*
+
+```
+Power Platform Environment Colored Banner is a productivity extension for Microsoft Power Platform users working across multiple environments — production, sandbox, developer, UAT, testing, and more.
+
+When switching between environments frequently, it's dangerously easy to perform actions in the wrong one. A configuration change, flow run, or data edit done in production instead of sandbox can have serious consequences. This extension eliminates that risk with a permanent, color-coded visual indicator at the top of every Power Platform page.
+
+KEY FEATURES
+
+• Color-coded banner — a slim 18 px strip is pinned to the top of every supported page. Each environment gets its own background color, configured by you.
+
+• Three-section layout — the left side shows the environment type (e.g. PRODUCTION), the center shows your custom description, and the right side displays an optional SVG icon. All text colors are calculated automatically to contrast with the background.
+
+• SVG icon per environment — upload any SVG file as a visual identifier for an environment. The icon color adapts to the banner contrast color automatically.
+
+• Edit environments — use the pencil button in the settings list to update color, type, description, or icon without re-entering the environment ID.
+
+• Custom environment type — beyond the seven presets (Production, Default, Sandbox, Trial, Developer, User Acceptance Testing, Testing) you can define any free-form type name.
+
+• Live filter — a search field above the environment list filters rows by ID, type, or description as you type.
+
+• Case-insensitive matching — environment IDs in URLs and saved settings are compared without regard to letter case, so mixed-case GUIDs always match correctly.
+
+• Settings sync — environment metadata is stored in chrome.storage.sync and synchronized across all your signed-in devices automatically. SVG icons are stored locally in chrome.storage.local.
+
+SUPPORTED PAGES
+
+- Power Apps (make.powerapps.com)
+- Power Automate (make.powerautomate.com)
+- Power Pages (make.powerpages.microsoft.com)
+- Power Platform Admin Center (admin.powerplatform.microsoft.com)
+- Power Apps – US Government (make.gov.powerapps.us)
+- Power Automate – US Government (make.gov.powerautomate.us)
+- Power Apps Preview (make.preview.powerapps.com)
+- Power Automate Preview (make.preview.powerautomate.com)
+
+HOW TO USE
+
+1. Click the extension icon to open the settings page.
+2. Enter the Environment ID (GUID) from the URL: make.powerapps.com/environments/<ID>/
+3. Choose a background color, environment type, and optionally a description and SVG icon.
+4. Click Save. The banner will appear immediately on any matching Power Platform page.
+5. To edit an entry later, click the pencil icon in the list, make your changes, and click Update.
+
+PRIVACY
+
+This extension does not collect, transmit, or share any personal data. All configuration is stored exclusively in your browser's local and sync storage. No external servers are contacted.
+```
+
+### Category
+```
+Productivity
+```
+
+### Language
+```
+English
+```
+
+### Homepage URL
+```
+https://citdev.pl/
+```
+
+### Support / contact URL
+```
+https://citdev.pl/
+```
+
+---
+
+## Permissions justification
+
+Both stores require an explanation for every permission declared in `manifest.json`.
+
+| Permission | Justification |
+|---|---|
+| `storage` | Used to save and load user-defined environment configurations (background color, environment type, description) via `chrome.storage.sync`, and SVG icon data via `chrome.storage.local`. No data leaves the browser. |
+
+### Host permissions (content scripts)
+
+The extension injects a content script on the following hosts solely to read the current URL path and display the banner:
+
+| Host | Reason |
+|---|---|
+| `https://make.powerapps.com/*` | Core Power Apps maker portal |
+| `https://make.powerautomate.com/*` | Power Automate maker portal |
+| `https://make.powerpages.microsoft.com/*` | Power Pages maker portal |
+| `https://admin.powerplatform.microsoft.com/*` | Power Platform Admin Center |
+| `https://make.gov.powerapps.us/*` | Power Apps — US Government cloud |
+| `https://make.gov.powerautomate.us/*` | Power Automate — US Government cloud |
+| `https://make.preview.powerapps.com/*` | Power Apps preview environment |
+| `https://make.preview.powerautomate.com/*` | Power Automate preview environment |
+
+The content script reads only `window.location.href` (to extract the environment ID from the URL path) and `chrome.storage` (to retrieve the user's saved configuration). It does not read, collect, or transmit any page content, user input, or personal data.
+
+---
+
+## Privacy policy
+
+*(Both stores require a privacy policy URL if the extension accesses user data or injects scripts into pages. A minimal policy text is provided below — host it at your domain.)*
+
+**Suggested URL:** `https://citdev.pl/privacy-policy-power-platform-environment-colored-banner/`
+
+**Suggested policy text:**
+
+```
+Privacy Policy — Power Platform Environment Colored Banner
+
+Last updated: 2026-06-20
+
+This extension does not collect, store on external servers, or transmit any personal data or usage information.
+
+All data entered by the user (environment IDs, colors, descriptions, SVG icons) is stored exclusively in the browser's built-in storage APIs (chrome.storage.sync and chrome.storage.local) and never leaves the browser, except for the standard Chrome sync mechanism that synchronizes chrome.storage.sync data between the user's own signed-in devices.
+
+The extension does not use analytics, crash reporting, advertising, or any third-party services.
+
+Contact: citdev.pl
+```
+
+---
+
+## Chrome Web Store — additional fields
+
+| Field | Value |
+|---|---|
+| Single-purpose description | Displays a color-coded identification banner on Microsoft Power Platform pages based on the current environment ID found in the URL. |
+| Manifest version | 3 |
+| Does it use remote code? | No |
+| Are any permissions required for the core functionality? | Yes — `storage` (to persist user configuration) and host permissions for Power Platform domains (to inject the banner). |
+
+### Required screenshots
+
+Minimum 1, recommended 3–5. Dimensions: **1280 × 800 px** or **640 × 400 px**.
+
+Suggested screenshots to prepare:
+1. Banner visible at the top of a Power Apps page (Production environment, red banner)
+2. Banner visible on a Power Automate page (Sandbox environment, green banner)
+3. Settings page — form for adding an environment
+4. Settings page — populated environments list with icons
+5. Settings page — edit mode with custom type input visible
+
+### Promotional tile (optional)
+
+Small tile: **440 × 280 px**
+Large tile: **920 × 680 px**
+Marquee: **1400 × 560 px**
+
+---
+
+## Microsoft Edge Add-ons — additional fields
+
+| Field | Value |
+|---|---|
+| Publisher display name | Karol Kozłowski \| CitDev |
+| Availability | All regions |
+| Age rating | Everyone |
+| Does the extension collect user data? | No |
+
+### Certification notes for Edge reviewers
+
+- The extension operates exclusively on Microsoft Power Platform domains.
+- It reads only the URL path to extract the environment ID and displays a visual overlay.
+- All user data stays in `chrome.storage` (compatible with Edge's `browser.storage`).
+- No remote code execution, no external network requests, no data collection.
+
+---
+
+## Version history
+
+| Version | Notes |
+|---|---|
+| 1.2 | Added SVG icon support, environment editing, three-section banner layout, custom environment type, live filter, toast notifications, case-insensitive ID matching, optimized URL monitoring, support for Power Pages and Admin Center |
+| 1.1 | Added support for US Government and Preview domains |
+| 1.0 | Initial release |

--- a/STORE_LISTING.md
+++ b/STORE_LISTING.md
@@ -120,23 +120,12 @@ The content script reads only `window.location.href` (to extract the environment
 
 *(Both stores require a privacy policy URL if the extension accesses user data or injects scripts into pages. A minimal policy text is provided below — host it at your domain.)*
 
-**Suggested URL:** `https://citdev.pl/privacy-policy-power-platform-environment-colored-banner/`
-
-**Suggested policy text:**
-
+**URL:**
 ```
-Privacy Policy — Power Platform Environment Colored Banner
-
-Last updated: 2026-06-20
-
-This extension does not collect, store on external servers, or transmit any personal data or usage information.
-
-All data entered by the user (environment IDs, colors, descriptions, SVG icons) is stored exclusively in the browser's built-in storage APIs (chrome.storage.sync and chrome.storage.local) and never leaves the browser, except for the standard Chrome sync mechanism that synchronizes chrome.storage.sync data between the user's own signed-in devices.
-
-The extension does not use analytics, crash reporting, advertising, or any third-party services.
-
-Contact: citdev.pl
+https://github.com/KarolFilipKozlowski/PowerPlatformEnvironmentColoredBanner/blob/main/PRIVACY_POLICY.md
 ```
+
+The privacy policy is maintained as `PRIVACY_POLICY.md` in this repository. Both Chrome Web Store and Microsoft Edge Add-ons accept GitHub repository URLs as valid privacy policy links.
 
 ---
 

--- a/STORE_LISTING.md
+++ b/STORE_LISTING.md
@@ -179,6 +179,6 @@ Marquee: **1400 × 560 px**
 
 | Version | Notes |
 |---|---|
-| 1.2 | Added SVG icon support, environment editing, three-section banner layout, custom environment type, live filter, toast notifications, case-insensitive ID matching, optimized URL monitoring, support for Power Pages and Admin Center |
+| 3.0 | Added SVG icon support, environment editing, three-section banner layout, custom environment type, live filter, toast notifications, post-update What's New notification, case-insensitive ID matching, optimized URL monitoring, support for Power Pages and Admin Center |
 | 1.1 | Added support for US Government and Preview domains |
 | 1.0 | Initial release |

--- a/background.js
+++ b/background.js
@@ -1,3 +1,12 @@
 chrome.action.onClicked.addListener(() => {
   chrome.runtime.openOptionsPage();
 });
+
+chrome.runtime.onInstalled.addListener((details) => {
+  if (details.reason === "update") {
+    const version = chrome.runtime.getManifest().version;
+    chrome.action.setBadgeText({ text: "NEW" });
+    chrome.action.setBadgeBackgroundColor({ color: "#0d6efd" });
+    chrome.storage.local.set({ showWhatsNew: true, whatsNewVersion: version });
+  }
+});

--- a/content.js
+++ b/content.js
@@ -21,9 +21,9 @@ function createEnvironmentBanner(environmentType, backgroundColor, environmentDe
     banner.style.left = "0";
     banner.style.width = "100%";
     banner.style.height = "18px";
-    banner.style.display = "flex";
+    banner.style.display = "grid";
+    banner.style.gridTemplateColumns = "minmax(0, 1fr) auto minmax(0, 1fr)";
     banner.style.alignItems = "center";
-    banner.style.justifyContent = "center";
     banner.style.fontSize = "12px";
     banner.style.zIndex = "9999";
     banner.style.boxShadow = "0 2px 4px rgba(0, 0, 0, 0.2)";
@@ -35,34 +35,54 @@ function createEnvironmentBanner(environmentType, backgroundColor, environmentDe
   banner.style.color = textColor;
   banner.innerHTML = "";
 
+  // Left: environment type
+  const leftSection = document.createElement("span");
+  leftSection.style.cssText = "padding-left:8px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;";
+  leftSection.textContent = `Environment type: ${environmentType.toUpperCase()}`;
+  banner.appendChild(leftSection);
+
+  // Center: description (truly centered via grid 1fr auto 1fr)
+  const centerSection = document.createElement("span");
+  centerSection.style.cssText = "text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;padding:0 4px;";
+  centerSection.textContent = environmentDesc || "";
+  banner.appendChild(centerSection);
+
+  // Right: SVG icon pushed to the right edge
+  const rightSection = document.createElement("span");
+  rightSection.style.cssText = "display:flex;justify-content:flex-end;align-items:center;padding-right:8px;";
+
   if (svgIcon) {
     const iconWrapper = document.createElement("span");
-    iconWrapper.style.cssText = "display:inline-flex;align-items:center;width:12px;height:12px;margin-right:5px;flex-shrink:0;overflow:hidden;";
+    iconWrapper.style.cssText = "display:inline-flex;align-items:center;width:12px;height:12px;overflow:hidden;flex-shrink:0;";
+    iconWrapper.style.color = textColor;
     iconWrapper.innerHTML = svgIcon;
     const svgEl = iconWrapper.querySelector("svg");
     if (svgEl) {
       svgEl.setAttribute("width", "12");
       svgEl.setAttribute("height", "12");
-      svgEl.style.cssText = "width:12px;height:12px;display:block;";
+      svgEl.style.cssText = "width:12px;height:12px;display:block;fill:currentColor;";
     }
-    banner.appendChild(iconWrapper);
+    rightSection.appendChild(iconWrapper);
   }
 
-  const textSpan = document.createElement("span");
-  textSpan.textContent = `Environment type: ${environmentType.toUpperCase()}${environmentDesc ? ` (${environmentDesc})` : ""}`;
-  banner.appendChild(textSpan);
+  banner.appendChild(rightSection);
 }
 
 // Function to retrieve environment data from chrome.storage
 function displayEnvironmentBanner(environmentId) {
   chrome.storage.sync.get("environments", (data) => {
     const environments = data.environments || {};
-    if (environments[environmentId]) {
-      const { environmentColor: color, environmentType: type, environmentDesc: desc } = environments[environmentId];
+
+    // Case-insensitive lookup: URL and stored keys may differ in letter case
+    const normalizedId = environmentId.toLowerCase();
+    const matchedKey = Object.keys(environments).find(k => k.toLowerCase() === normalizedId);
+
+    if (matchedKey) {
+      const { environmentColor: color, environmentType: type, environmentDesc: desc } = environments[matchedKey];
 
       chrome.storage.local.get("environmentIcons", (iconData) => {
         const icons = iconData.environmentIcons || {};
-        createEnvironmentBanner(type, color, desc, icons[environmentId] || null);
+        createEnvironmentBanner(type, color, desc, icons[matchedKey] || null);
       });
     } else {
       const banner = document.getElementById("environment-banner");
@@ -82,16 +102,20 @@ function monitorEnvironmentChanges() {
     const url = new URL(window.location.href);
     const pathSegments = url.pathname.split('/');
 
-    const environmentIdIndex = pathSegments.includes("environments")
-      ? pathSegments.indexOf("environments") + 1
-      : pathSegments.includes("e")
-      ? pathSegments.indexOf("e") + 1
+    // Normalize to lowercase for case-insensitive segment matching
+    const lowerSegments = pathSegments.map(s => s.toLowerCase());
+
+    const environmentIdIndex = lowerSegments.includes("environments")
+      ? lowerSegments.indexOf("environments") + 1
+      : lowerSegments.includes("e")
+      ? lowerSegments.indexOf("e") + 1
       : -1;
 
     const environmentId = environmentIdIndex > 0 ? pathSegments[environmentIdIndex] : null;
 
-    if (environmentId && environmentId !== lastEnvironmentId) {
-      lastEnvironmentId = environmentId;
+    // Compare normalized so casing changes in the URL don't trigger a redundant update
+    if (environmentId && environmentId.toLowerCase() !== lastEnvironmentId) {
+      lastEnvironmentId = environmentId.toLowerCase();
       displayEnvironmentBanner(environmentId);
     }
   };

--- a/content.js
+++ b/content.js
@@ -97,6 +97,7 @@ function displayEnvironmentBanner(environmentId) {
 // Function to monitor URL changes and update the banner
 function monitorEnvironmentChanges() {
   let lastEnvironmentId = null;
+  let isChecking = false;
 
   const checkEnvironmentId = () => {
     const url = new URL(window.location.href);
@@ -113,17 +114,31 @@ function monitorEnvironmentChanges() {
 
     const environmentId = environmentIdIndex > 0 ? pathSegments[environmentIdIndex] : null;
 
-    // Compare normalized so casing changes in the URL don't trigger a redundant update
     if (environmentId && environmentId.toLowerCase() !== lastEnvironmentId) {
       lastEnvironmentId = environmentId.toLowerCase();
       displayEnvironmentBanner(environmentId);
     }
   };
 
-  const observer = new MutationObserver(checkEnvironmentId);
+  // Throttle MutationObserver callbacks via requestAnimationFrame
+  const throttledCheck = () => {
+    if (isChecking) return;
+    isChecking = true;
+    requestAnimationFrame(() => {
+      checkEnvironmentId();
+      isChecking = false;
+    });
+  };
+
+  const observer = new MutationObserver(throttledCheck);
   observer.observe(document.body, { childList: true, subtree: true });
 
-  setInterval(checkEnvironmentId, 1000);
+  // History API events as additional triggers (cover back/forward navigation)
+  window.addEventListener("popstate", checkEnvironmentId);
+  window.addEventListener("hashchange", checkEnvironmentId);
+
+  // Initial check on page load
+  checkEnvironmentId();
 }
 
 // Start monitoring environment changes on page load

--- a/content.js
+++ b/content.js
@@ -1,71 +1,76 @@
 // Function to calculate a contrasting text color based on the background color
 function getContrastColor(hexColor) {
-  // Remove hash if present
   hexColor = hexColor.replace("#", "");
-
-  // Convert hex to RGB
   const r = parseInt(hexColor.substr(0, 2), 16);
   const g = parseInt(hexColor.substr(2, 2), 16);
   const b = parseInt(hexColor.substr(4, 2), 16);
-
-  // Calculate luminance
   const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-
-  // Return black for light backgrounds and white for dark backgrounds
   return luminance > 0.5 ? "#000000" : "#ffffff";
 }
 
 // Function that creates a banner and adds it to the page
-function createEnvironmentBanner(environmentId, environmentType, backgroundColor, environmentDesc) {
-  // Determine the contrasting text color
+function createEnvironmentBanner(environmentType, backgroundColor, environmentDesc, svgIcon) {
   const textColor = getContrastColor(backgroundColor);
 
-  // Check if the banner already exists to avoid duplication
   let banner = document.getElementById("environment-banner");
   if (!banner) {
-      banner = document.createElement("div");
-      banner.id = "environment-banner";
-      banner.style.position = "fixed";
-      banner.style.top = "0";
-      banner.style.left = "0";
-      banner.style.width = "100%";
-      banner.style.height = "18px";
-      banner.style.display = "flex";
-      banner.style.alignItems = "center";
-      banner.style.justifyContent = "center";
-      banner.style.fontSize = "12px";
-      banner.style.zIndex = "9999";
-      banner.style.boxShadow = "0 2px 4px rgba(0, 0, 0, 0.2)";
-      document.body.prepend(banner);
-      document.body.style.paddingTop = "18px";
+    banner = document.createElement("div");
+    banner.id = "environment-banner";
+    banner.style.position = "fixed";
+    banner.style.top = "0";
+    banner.style.left = "0";
+    banner.style.width = "100%";
+    banner.style.height = "18px";
+    banner.style.display = "flex";
+    banner.style.alignItems = "center";
+    banner.style.justifyContent = "center";
+    banner.style.fontSize = "12px";
+    banner.style.zIndex = "9999";
+    banner.style.boxShadow = "0 2px 4px rgba(0, 0, 0, 0.2)";
+    document.body.prepend(banner);
+    document.body.style.paddingTop = "18px";
   }
-  
-  // Prepare the banner text with description in parentheses if it's not empty
-  const bannerText = `Environment type: ${environmentType.toUpperCase()}${environmentDesc ? ` (${environmentDesc})` : ""}`;
 
-  // Apply background and text colors
   banner.style.backgroundColor = backgroundColor;
   banner.style.color = textColor;
+  banner.innerHTML = "";
 
-  // Set text on the banner
-  banner.innerText = bannerText;
+  if (svgIcon) {
+    const iconWrapper = document.createElement("span");
+    iconWrapper.style.cssText = "display:inline-flex;align-items:center;width:12px;height:12px;margin-right:5px;flex-shrink:0;overflow:hidden;";
+    iconWrapper.innerHTML = svgIcon;
+    const svgEl = iconWrapper.querySelector("svg");
+    if (svgEl) {
+      svgEl.setAttribute("width", "12");
+      svgEl.setAttribute("height", "12");
+      svgEl.style.cssText = "width:12px;height:12px;display:block;";
+    }
+    banner.appendChild(iconWrapper);
+  }
+
+  const textSpan = document.createElement("span");
+  textSpan.textContent = `Environment type: ${environmentType.toUpperCase()}${environmentDesc ? ` (${environmentDesc})` : ""}`;
+  banner.appendChild(textSpan);
 }
 
-// Function to retrieve environment data from `chrome.storage`
+// Function to retrieve environment data from chrome.storage
 function displayEnvironmentBanner(environmentId) {
   chrome.storage.sync.get("environments", (data) => {
-      const environments = data.environments || {};
-      if (environments[environmentId]) {
-          const { "environmentColor": color, "environmentType": type, "environmentDesc": desc } = environments[environmentId];
-          createEnvironmentBanner(environmentId, type, color, desc);
-      } else {
-          // If the environment is not saved, remove the banner if it exists
-          const banner = document.getElementById("environment-banner");
-          if (banner) {
-              banner.remove();
-              document.body.style.paddingTop = "0";
-          }
+    const environments = data.environments || {};
+    if (environments[environmentId]) {
+      const { environmentColor: color, environmentType: type, environmentDesc: desc } = environments[environmentId];
+
+      chrome.storage.local.get("environmentIcons", (iconData) => {
+        const icons = iconData.environmentIcons || {};
+        createEnvironmentBanner(type, color, desc, icons[environmentId] || null);
+      });
+    } else {
+      const banner = document.getElementById("environment-banner");
+      if (banner) {
+        banner.remove();
+        document.body.style.paddingTop = "0";
       }
+    }
   });
 }
 
@@ -73,32 +78,27 @@ function displayEnvironmentBanner(environmentId) {
 function monitorEnvironmentChanges() {
   let lastEnvironmentId = null;
 
-  // Check if the URL contains an environment ID
   const checkEnvironmentId = () => {
-      const url = new URL(window.location.href);
-      const pathSegments = url.pathname.split('/');
+    const url = new URL(window.location.href);
+    const pathSegments = url.pathname.split('/');
 
-      // Check both /environments/ and /e/ for the environment ID
-      const environmentIdIndex = pathSegments.includes("environments")
-          ? pathSegments.indexOf("environments") + 1
-          : pathSegments.includes("e")
-          ? pathSegments.indexOf("e") + 1
-          : -1;
+    const environmentIdIndex = pathSegments.includes("environments")
+      ? pathSegments.indexOf("environments") + 1
+      : pathSegments.includes("e")
+      ? pathSegments.indexOf("e") + 1
+      : -1;
 
-      const environmentId = environmentIdIndex > 0 ? pathSegments[environmentIdIndex] : null;
+    const environmentId = environmentIdIndex > 0 ? pathSegments[environmentIdIndex] : null;
 
-      // Update the banner if the environment ID has changed
-      if (environmentId && environmentId !== lastEnvironmentId) {
-          lastEnvironmentId = environmentId;
-          displayEnvironmentBanner(environmentId);
-      }
+    if (environmentId && environmentId !== lastEnvironmentId) {
+      lastEnvironmentId = environmentId;
+      displayEnvironmentBanner(environmentId);
+    }
   };
 
-  // Use `MutationObserver` to detect changes in the document structure
   const observer = new MutationObserver(checkEnvironmentId);
   observer.observe(document.body, { childList: true, subtree: true });
 
-  // Also check the environment ID every few seconds in case `MutationObserver` misses changes
   setInterval(checkEnvironmentId, 1000);
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,10 @@
         "https://make.gov.powerapps.us/*",
 
         "https://make.preview.powerapps.com/*",
-        "https://make.preview.powerautomate.com/*"
+        "https://make.preview.powerautomate.com/*",
+
+        "https://make.powerpages.microsoft.com/*",
+        "https://admin.powerplatform.microsoft.com/*"
       ],
       "js": [
         "content.js"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Power Platform Environment Colored Banner",
-  "version": "1.2",
+  "version": "3.0",
   "description": "Displays a color-coded banner on Power Platform pages, showing environment type and optional description.",
   "author": "Karol Kozłowski | CitDev",
   "homepage_url": "https://citdev.pl/",

--- a/options.html
+++ b/options.html
@@ -13,6 +13,19 @@
     body {
       background-image: url("bg.webp");
     }
+    .icon-cell {
+      width: 40px;
+    }
+    .icon-cell svg {
+      width: 24px;
+      height: 24px;
+      display: block;
+    }
+    #icon-preview svg {
+      width: 40px;
+      height: 40px;
+      display: block;
+    }
   </style>
 </head>
 
@@ -21,19 +34,22 @@
     <!-- Environment configuration form -->
     <form id="environment-form">
       <div class="mb-3">
-        <h3 class="h3 mb-3 fw-normal"><img class="mb-3" src="icon48.png" alt="" width="48" height="48"> Add environment:</h3>
+        <h3 class="h3 mb-3 fw-normal">
+          <img class="mb-3" src="icon48.png" alt="" width="48" height="48">
+          <span id="form-title-text">Add environment:</span>
+        </h3>
       </div>
       <!-- Input for environment ID -->
       <div class="mb-3">
         <label for="environment-id">Environment ID</label>
         <input type="text" class="form-control" id="environment-id" required>
-        <div id="email-environment-id" class="form-text">Copy the ID from URL make.powerapps.com/environments/<u>ID</u>/ (or environments/<u>Default-ID</u>).</div>
+        <div class="form-text">Copy the ID from URL make.powerapps.com/environments/<u>ID</u>/ (or environments/<u>Default-ID</u>).</div>
       </div>
       <div class="row">
         <!-- Input for background color -->
         <div class="mb-3 col-md-2">
           <label for="environment-color">Background color</label>
-          <input type="color" class="form-control" style="width: 76px; height: 38px;" id="environment-color" required>
+          <input type="color" class="form-control" style="width: 76px; height: 38px;" id="environment-color" value="#ffffff" required>
         </div>
         <!-- Dropdown for environment type -->
         <div class="mb-3 col-md-3">
@@ -54,7 +70,23 @@
           <input type="text" class="form-control" id="environment-desc">
         </div>
       </div>
-      <button class="btn btn-primary" style="width: 100px;" type="submit">Save</button>
+      <!-- SVG icon upload -->
+      <div class="mb-3">
+        <label for="environment-icon">Environment icon (SVG)</label>
+        <div class="d-flex align-items-center gap-2 mt-1">
+          <input type="file" class="form-control" id="environment-icon" accept=".svg,image/svg+xml">
+          <div id="icon-preview"
+               class="border rounded d-flex align-items-center justify-content-center flex-shrink-0"
+               style="width: 48px; height: 48px;"></div>
+          <button type="button" id="remove-icon-btn" class="btn btn-sm btn-outline-secondary flex-shrink-0" style="display: none;" title="Remove icon">
+            <i class="bi bi-x-circle"></i>
+          </button>
+        </div>
+      </div>
+      <div class="d-flex gap-2">
+        <button class="btn btn-primary" style="width: 100px;" id="submit-btn" type="submit">Save</button>
+        <button class="btn btn-outline-secondary" id="cancel-btn" type="button" style="display: none;">Cancel</button>
+      </div>
     </form>
     <hr>
     <h4 class="h4 mb-3 fw-normal">Added environments:</h4>
@@ -64,11 +96,12 @@
       <thead>
         <tr>
           <th scope="col">#</th>
+          <th scope="col" style="width: 40px;">Icon</th>
           <th scope="col">Environment ID</th>
-          <th scope="col" style="width: 210px;">Environment type</th>
-          <th scope="col" style="width: 210px;">Background color</th>
+          <th scope="col" style="width: 180px;">Environment type</th>
+          <th scope="col" style="width: 140px;">Background color</th>
           <th scope="col">Description</th>
-          <th scope="col"></th>
+          <th scope="col" style="width: 90px;"></th>
         </tr>
       </thead>
       <tbody id="environment-list"></tbody>

--- a/options.html
+++ b/options.html
@@ -122,6 +122,12 @@
       </thead>
       <tbody id="environment-list"></tbody>
     </table>
+    <hr>
+    <div class="text-center py-2">
+      <a href="https://www.buymeacoffee.com/citdev" target="_blank">
+        <img src="https://cdn.buymeacoffee.com/buttons/v2/default-blue.png" alt="Buy Me a Coffee" style="height: 60px !important; width: 217px !important;">
+      </a>
+    </div>
   </main>
 
   <!-- Toast notifications (bottom-right) -->

--- a/options.html
+++ b/options.html
@@ -38,6 +38,25 @@
 
 <body class="d-flex align-items-center py-4 bg-body-tertiary">
   <main class="form-signin m-auto border border-light-subtle shadow p-3 bg-white rounded w-50">
+    <!-- What's New banner (shown once after an update, dismissed by user) -->
+    <div id="whats-new" class="alert alert-primary mb-4" style="display: none;">
+      <div class="d-flex align-items-center mb-2">
+        <i class="bi bi-stars me-2 fs-5"></i>
+        <strong>What's new in version <span id="whats-new-version"></span></strong>
+        <button type="button" id="whats-new-close" class="btn-close ms-auto" aria-label="Dismiss"></button>
+      </div>
+      <ul class="mb-0 small">
+        <li>SVG icon per environment — upload a custom icon displayed in the banner</li>
+        <li>Edit existing environments directly from the list (pencil button)</li>
+        <li>Custom environment type — define your own type name beyond the presets</li>
+        <li>Three-section banner layout — type on the left, description centered, icon on the right</li>
+        <li>Live search — filter environments by ID, type or description</li>
+        <li>Toast notifications — no more blocking alert() dialogs</li>
+        <li>Support for Power Pages and Power Platform Admin Center</li>
+        <li>Case-insensitive environment ID matching</li>
+      </ul>
+    </div>
+
     <!-- Environment configuration form -->
     <form id="environment-form">
       <div class="mb-3">

--- a/options.html
+++ b/options.html
@@ -26,6 +26,13 @@
       height: 40px;
       display: block;
     }
+    @keyframes toastSlideIn {
+      from { opacity: 0; transform: translateX(16px); }
+      to   { opacity: 1; transform: translateX(0); }
+    }
+    #toast-container .alert {
+      animation: toastSlideIn 0.25s ease;
+    }
   </style>
 </head>
 
@@ -62,6 +69,7 @@
             <option value="Developer">Developer</option>
             <option value="User Acceptance Testing">User Acceptance Testing</option>
             <option value="Testing">Testing</option>
+            <option value="Custom">Custom…</option>
           </select>
         </div>
         <!-- Input for description -->
@@ -69,6 +77,11 @@
           <label for="environment-desc">Description</label>
           <input type="text" class="form-control" id="environment-desc">
         </div>
+      </div>
+      <!-- Custom type input (shown only when "Custom…" is selected) -->
+      <div class="mb-3" id="custom-type-row" style="display: none;">
+        <label for="environment-type-custom">Custom environment type</label>
+        <input type="text" class="form-control" id="environment-type-custom" placeholder="Enter custom type name..." maxlength="50">
       </div>
       <!-- SVG icon upload -->
       <div class="mb-3">
@@ -89,7 +102,10 @@
       </div>
     </form>
     <hr>
-    <h4 class="h4 mb-3 fw-normal">Added environments:</h4>
+    <div class="d-flex align-items-center justify-content-between mb-2">
+      <h4 class="h4 mb-0 fw-normal">Added environments:</h4>
+      <input type="search" id="env-search" class="form-control form-control-sm w-50" placeholder="Filter by ID, type or description...">
+    </div>
 
     <!-- Table to display saved environments -->
     <table class="table table-hover">
@@ -107,6 +123,33 @@
       <tbody id="environment-list"></tbody>
     </table>
   </main>
+
+  <!-- Toast notifications (bottom-right) -->
+  <div id="toast-container" class="position-fixed bottom-0 end-0 p-3" style="z-index: 10000;"></div>
+
+  <!-- Delete confirmation modal -->
+  <div id="delete-modal"
+       style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.5); z-index:10001; align-items:center; justify-content:center;">
+    <div style="max-width:480px; width:90%;">
+      <div class="modal-content shadow-lg rounded">
+        <div class="modal-header border-bottom px-4 py-3">
+          <h5 class="modal-title mb-0">
+            <i class="bi bi-exclamation-triangle-fill text-danger me-2"></i>Remove environment
+          </h5>
+        </div>
+        <div class="modal-body px-4 py-3">
+          <p class="mb-1">Are you sure you want to remove:</p>
+          <code id="delete-modal-id" class="text-break d-block mt-1 fs-6"></code>
+        </div>
+        <div class="modal-footer border-top px-4 py-3 d-flex gap-2 justify-content-end">
+          <button type="button" class="btn btn-secondary" id="delete-modal-cancel">Cancel</button>
+          <button type="button" class="btn btn-danger" id="delete-modal-confirm">
+            <i class="bi bi-trash"></i> Remove
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
 
   <script src="options.js"></script>
 </body>

--- a/options.js
+++ b/options.js
@@ -1,77 +1,187 @@
-// Function to load and display saved environments in the table
+let editMode = false;
+let editingId = null;
+let pendingSvgContent = null;
+
+function sanitizeSvg(svgString) {
+  svgString = svgString.replace(/<script[\s\S]*?<\/script>/gi, "");
+  svgString = svgString.replace(/\s+on\w+\s*=\s*["'][^"']*["']/gi, "");
+  svgString = svgString.replace(/javascript:/gi, "");
+  return svgString;
+}
+
 function loadEnvironments() {
-  chrome.storage.sync.get("environments", (data) => {
-    const environments = data.environments || {};
-    const listElement = document.getElementById("environment-list");
-    listElement.innerHTML = ""; // Clear the table
+  chrome.storage.sync.get("environments", (syncData) => {
+    chrome.storage.local.get("environmentIcons", (localData) => {
+      const environments = syncData.environments || {};
+      const icons = localData.environmentIcons || {};
+      const listElement = document.getElementById("environment-list");
+      listElement.innerHTML = "";
 
-    let index = 1;
-    for (const [id, envData] of Object.entries(environments)) {
-      const row = document.createElement("tr");
+      let index = 1;
+      for (const [id, envData] of Object.entries(environments)) {
+        const row = document.createElement("tr");
 
-      row.innerHTML = `
-        <th class="align-middle" scope="row">${index}</th>
-        <td class="align-middle">${id}</td>
-        <td class="align-middle">${envData["environmentType"]}</td>
-        <td class="align-middle"><i class="bi bi-paint-bucket" style="color: ${envData["environmentColor"]};"></i> ${envData["environmentColor"]}</td>
-        <td class="align-middle">${envData["environmentDesc"] || ""}</td>
-        <td class="align-middle"><button class="delete-btn btn btn-outline-danger" data-id="${id}">Remove</button></td>
-      `;
+        row.innerHTML = `
+          <th class="align-middle" scope="row">${index}</th>
+          <td class="align-middle icon-cell"></td>
+          <td class="align-middle" style="word-break: break-all;">${id}</td>
+          <td class="align-middle">${envData.environmentType}</td>
+          <td class="align-middle"><i class="bi bi-paint-bucket" style="color: ${envData.environmentColor};"></i> ${envData.environmentColor}</td>
+          <td class="align-middle">${envData.environmentDesc || ""}</td>
+          <td class="align-middle">
+            <div class="d-flex gap-1">
+              <button class="edit-btn btn btn-outline-primary btn-sm" data-id="${id}" title="Edit">
+                <i class="bi bi-pencil"></i>
+              </button>
+              <button class="delete-btn btn btn-outline-danger btn-sm" data-id="${id}" title="Remove">
+                <i class="bi bi-trash"></i>
+              </button>
+            </div>
+          </td>
+        `;
 
-      listElement.appendChild(row);
-      index++;
-    }
+        // Inject SVG icon safely outside the template literal
+        const iconCell = row.querySelector(".icon-cell");
+        if (icons[id]) {
+          iconCell.innerHTML = icons[id];
+        } else {
+          iconCell.innerHTML = '<span class="text-muted">—</span>';
+        }
 
-    // Attach event listeners to remove buttons
-    document.querySelectorAll(".delete-btn").forEach(button => {
-      button.addEventListener("click", (event) => {
-        const environmentId = event.target.getAttribute("data-id");
-        deleteEnvironment(environmentId);
+        listElement.appendChild(row);
+        index++;
+      }
+
+      document.querySelectorAll(".edit-btn").forEach(button => {
+        button.addEventListener("click", (event) => {
+          const id = event.currentTarget.getAttribute("data-id");
+          startEditMode(id, environments[id], icons[id] || null);
+        });
+      });
+
+      document.querySelectorAll(".delete-btn").forEach(button => {
+        button.addEventListener("click", (event) => {
+          const id = event.currentTarget.getAttribute("data-id");
+          deleteEnvironment(id);
+        });
       });
     });
   });
 }
 
-// Function to delete an environment from storage
+function startEditMode(id, envData, svgIcon) {
+  editMode = true;
+  editingId = id;
+  pendingSvgContent = svgIcon;
+
+  document.getElementById("environment-id").value = id;
+  document.getElementById("environment-id").readOnly = true;
+  document.getElementById("environment-color").value = envData.environmentColor;
+  document.getElementById("environment-type").value = envData.environmentType;
+  document.getElementById("environment-desc").value = envData.environmentDesc || "";
+
+  const iconPreview = document.getElementById("icon-preview");
+  iconPreview.innerHTML = svgIcon || "";
+  document.getElementById("remove-icon-btn").style.display = svgIcon ? "inline-flex" : "none";
+
+  document.getElementById("form-title-text").textContent = "Edit environment:";
+  document.getElementById("submit-btn").textContent = "Update";
+  document.getElementById("cancel-btn").style.display = "inline-block";
+
+  document.getElementById("environment-form").scrollIntoView({ behavior: "smooth" });
+}
+
+function resetForm() {
+  editMode = false;
+  editingId = null;
+  pendingSvgContent = null;
+
+  document.getElementById("environment-id").value = "";
+  document.getElementById("environment-id").readOnly = false;
+  document.getElementById("environment-color").value = "#ffffff";
+  document.getElementById("environment-type").value = "Sandbox";
+  document.getElementById("environment-desc").value = "";
+  document.getElementById("environment-icon").value = "";
+  document.getElementById("icon-preview").innerHTML = "";
+  document.getElementById("remove-icon-btn").style.display = "none";
+
+  document.getElementById("form-title-text").textContent = "Add environment:";
+  document.getElementById("submit-btn").textContent = "Save";
+  document.getElementById("cancel-btn").style.display = "none";
+}
+
 function deleteEnvironment(environmentId) {
+  if (!confirm(`Remove environment "${environmentId}"?`)) return;
+
   chrome.storage.sync.get("environments", (data) => {
     const environments = data.environments || {};
     delete environments[environmentId];
 
     chrome.storage.sync.set({ environments }, () => {
-      alert(`Environment ${environmentId} has been removed`);
-      loadEnvironments();
+      chrome.storage.local.get("environmentIcons", (iconData) => {
+        const icons = iconData.environmentIcons || {};
+        delete icons[environmentId];
+        chrome.storage.local.set({ environmentIcons: icons }, () => {
+          if (editMode && editingId === environmentId) resetForm();
+          loadEnvironments();
+        });
+      });
     });
   });
 }
 
-// Function to save a new environment to storage
+document.getElementById("environment-icon").addEventListener("change", (event) => {
+  const file = event.target.files[0];
+  if (!file) return;
+
+  const reader = new FileReader();
+  reader.onload = (e) => {
+    const svg = sanitizeSvg(e.target.result);
+    pendingSvgContent = svg;
+    document.getElementById("icon-preview").innerHTML = svg;
+    document.getElementById("remove-icon-btn").style.display = "inline-flex";
+  };
+  reader.readAsText(file);
+});
+
+document.getElementById("remove-icon-btn").addEventListener("click", () => {
+  pendingSvgContent = null;
+  document.getElementById("environment-icon").value = "";
+  document.getElementById("icon-preview").innerHTML = "";
+  document.getElementById("remove-icon-btn").style.display = "none";
+});
+
+document.getElementById("cancel-btn").addEventListener("click", resetForm);
+
 document.getElementById("environment-form").addEventListener("submit", (event) => {
   event.preventDefault();
-  
-  const environmentId = document.getElementById("environment-id").value;
+
+  const environmentId = document.getElementById("environment-id").value.trim();
   const environmentColor = document.getElementById("environment-color").value;
   const environmentType = document.getElementById("environment-type").value;
-  const environmentDesc = document.getElementById("environment-desc").value;
+  const environmentDesc = document.getElementById("environment-desc").value.trim();
 
   chrome.storage.sync.get("environments", (data) => {
     const environments = data.environments || {};
-    
-    // Add or replace the environment with the same ID
     environments[environmentId] = { environmentColor, environmentType, environmentDesc };
 
     chrome.storage.sync.set({ environments }, () => {
-      alert(`Environment ${environmentId} has been saved or updated.`);
-      loadEnvironments();
+      chrome.storage.local.get("environmentIcons", (iconData) => {
+        const icons = iconData.environmentIcons || {};
+
+        if (pendingSvgContent) {
+          icons[environmentId] = pendingSvgContent;
+        } else {
+          delete icons[environmentId];
+        }
+
+        chrome.storage.local.set({ environmentIcons: icons }, () => {
+          resetForm();
+          loadEnvironments();
+        });
+      });
     });
   });
-
-  // Clear form fields after saving
-  document.getElementById("environment-id").value = "";
-  document.getElementById("environment-color").value = "#ffffff";
-  document.getElementById("environment-type").selectedIndex = 0; // Reset environment type to the first option
-  document.getElementById("environment-desc").value = "";
 });
 
-// Load environments when the page loads
 loadEnvironments();

--- a/options.js
+++ b/options.js
@@ -1,6 +1,18 @@
+// ---- State ----
+
 let editMode = false;
 let editingId = null;
 let pendingSvgContent = null;
+let pendingDeleteId = null;
+let cachedEnvironments = {};
+let cachedIcons = {};
+
+const PRESET_TYPES = [
+  "Production", "Default", "Sandbox", "Trial",
+  "Developer", "User Acceptance Testing", "Testing"
+];
+
+// ---- Utilities ----
 
 function sanitizeSvg(svgString) {
   svgString = svgString.replace(/<script[\s\S]*?<\/script>/gi, "");
@@ -9,16 +21,56 @@ function sanitizeSvg(svgString) {
   return svgString;
 }
 
+function showToast(message, type = "success") {
+  const container = document.getElementById("toast-container");
+  const toast = document.createElement("div");
+  toast.className = `alert alert-${type} mb-1 py-2 px-3`;
+  toast.style.minWidth = "200px";
+  toast.style.fontSize = "0.875rem";
+  toast.textContent = message;
+  container.appendChild(toast);
+  setTimeout(() => {
+    toast.style.transition = "opacity 0.4s";
+    toast.style.opacity = "0";
+    setTimeout(() => toast.remove(), 400);
+  }, 2600);
+}
+
+function showDeleteModal(id) {
+  pendingDeleteId = id;
+  document.getElementById("delete-modal-id").textContent = id;
+  document.getElementById("delete-modal").style.display = "flex";
+}
+
+function hideDeleteModal() {
+  pendingDeleteId = null;
+  document.getElementById("delete-modal").style.display = "none";
+}
+
+function applyFilter() {
+  const query = document.getElementById("env-search").value.toLowerCase();
+  document.querySelectorAll("#environment-list tr").forEach(row => {
+    // cells: 0=#, 1=icon, 2=id, 3=type, 4=color, 5=desc, 6=actions
+    const id   = (row.cells[2]?.textContent || "").toLowerCase();
+    const type = (row.cells[3]?.textContent || "").toLowerCase();
+    const desc = (row.cells[5]?.textContent || "").toLowerCase();
+    row.style.display = (!query || id.includes(query) || type.includes(query) || desc.includes(query)) ? "" : "none";
+  });
+}
+
+// ---- Environment list ----
+
 function loadEnvironments() {
   chrome.storage.sync.get("environments", (syncData) => {
     chrome.storage.local.get("environmentIcons", (localData) => {
-      const environments = syncData.environments || {};
-      const icons = localData.environmentIcons || {};
+      cachedEnvironments = syncData.environments || {};
+      cachedIcons = localData.environmentIcons || {};
+
       const listElement = document.getElementById("environment-list");
       listElement.innerHTML = "";
 
       let index = 1;
-      for (const [id, envData] of Object.entries(environments)) {
+      for (const [id, envData] of Object.entries(cachedEnvironments)) {
         const row = document.createElement("tr");
 
         row.innerHTML = `
@@ -42,8 +94,8 @@ function loadEnvironments() {
 
         // Inject SVG icon safely outside the template literal
         const iconCell = row.querySelector(".icon-cell");
-        if (icons[id]) {
-          iconCell.innerHTML = icons[id];
+        if (cachedIcons[id]) {
+          iconCell.innerHTML = cachedIcons[id];
         } else {
           iconCell.innerHTML = '<span class="text-muted">—</span>';
         }
@@ -52,22 +104,12 @@ function loadEnvironments() {
         index++;
       }
 
-      document.querySelectorAll(".edit-btn").forEach(button => {
-        button.addEventListener("click", (event) => {
-          const id = event.currentTarget.getAttribute("data-id");
-          startEditMode(id, environments[id], icons[id] || null);
-        });
-      });
-
-      document.querySelectorAll(".delete-btn").forEach(button => {
-        button.addEventListener("click", (event) => {
-          const id = event.currentTarget.getAttribute("data-id");
-          deleteEnvironment(id);
-        });
-      });
+      applyFilter();
     });
   });
 }
+
+// ---- Edit mode ----
 
 function startEditMode(id, envData, svgIcon) {
   editMode = true;
@@ -77,8 +119,17 @@ function startEditMode(id, envData, svgIcon) {
   document.getElementById("environment-id").value = id;
   document.getElementById("environment-id").readOnly = true;
   document.getElementById("environment-color").value = envData.environmentColor;
-  document.getElementById("environment-type").value = envData.environmentType;
   document.getElementById("environment-desc").value = envData.environmentDesc || "";
+
+  if (PRESET_TYPES.includes(envData.environmentType)) {
+    document.getElementById("environment-type").value = envData.environmentType;
+    document.getElementById("environment-type-custom").value = "";
+    document.getElementById("custom-type-row").style.display = "none";
+  } else {
+    document.getElementById("environment-type").value = "Custom";
+    document.getElementById("environment-type-custom").value = envData.environmentType;
+    document.getElementById("custom-type-row").style.display = "block";
+  }
 
   const iconPreview = document.getElementById("icon-preview");
   iconPreview.innerHTML = svgIcon || "";
@@ -100,6 +151,8 @@ function resetForm() {
   document.getElementById("environment-id").readOnly = false;
   document.getElementById("environment-color").value = "#ffffff";
   document.getElementById("environment-type").value = "Sandbox";
+  document.getElementById("environment-type-custom").value = "";
+  document.getElementById("custom-type-row").style.display = "none";
   document.getElementById("environment-desc").value = "";
   document.getElementById("environment-icon").value = "";
   document.getElementById("icon-preview").innerHTML = "";
@@ -110,26 +163,62 @@ function resetForm() {
   document.getElementById("cancel-btn").style.display = "none";
 }
 
-function deleteEnvironment(environmentId) {
-  if (!confirm(`Remove environment "${environmentId}"?`)) return;
+// ---- Event listeners ----
+
+// C1 — Event delegation on table (single listener, prevents memory leak on repeated loadEnvironments())
+document.getElementById("environment-list").addEventListener("click", (event) => {
+  const editBtn = event.target.closest(".edit-btn");
+  const deleteBtn = event.target.closest(".delete-btn");
+
+  if (editBtn) {
+    const id = editBtn.getAttribute("data-id");
+    startEditMode(id, cachedEnvironments[id], cachedIcons[id] || null);
+  } else if (deleteBtn) {
+    const id = deleteBtn.getAttribute("data-id");
+    showDeleteModal(id);
+  }
+});
+
+// Delete modal — cancel
+document.getElementById("delete-modal-cancel").addEventListener("click", hideDeleteModal);
+
+// Delete modal — confirm
+document.getElementById("delete-modal-confirm").addEventListener("click", () => {
+  const id = pendingDeleteId;
+  if (!id) return;
+  hideDeleteModal();
 
   chrome.storage.sync.get("environments", (data) => {
     const environments = data.environments || {};
-    delete environments[environmentId];
-
+    delete environments[id];
     chrome.storage.sync.set({ environments }, () => {
       chrome.storage.local.get("environmentIcons", (iconData) => {
         const icons = iconData.environmentIcons || {};
-        delete icons[environmentId];
+        delete icons[id];
         chrome.storage.local.set({ environmentIcons: icons }, () => {
-          if (editMode && editingId === environmentId) resetForm();
+          if (editMode && editingId === id) resetForm();
+          showToast("Environment removed.", "success");
           loadEnvironments();
         });
       });
     });
   });
-}
+});
 
+// B2 — Show/hide custom type input based on select value
+document.getElementById("environment-type").addEventListener("change", (event) => {
+  const customRow = document.getElementById("custom-type-row");
+  const customInput = document.getElementById("environment-type-custom");
+  if (event.target.value === "Custom") {
+    customRow.style.display = "block";
+    customInput.focus();
+  } else {
+    customRow.style.display = "none";
+    customInput.value = "";
+  }
+});
+
+// SVG file picker
 document.getElementById("environment-icon").addEventListener("change", (event) => {
   const file = event.target.files[0];
   if (!file) return;
@@ -144,6 +233,7 @@ document.getElementById("environment-icon").addEventListener("change", (event) =
   reader.readAsText(file);
 });
 
+// Remove icon
 document.getElementById("remove-icon-btn").addEventListener("click", () => {
   pendingSvgContent = null;
   document.getElementById("environment-icon").value = "";
@@ -151,15 +241,29 @@ document.getElementById("remove-icon-btn").addEventListener("click", () => {
   document.getElementById("remove-icon-btn").style.display = "none";
 });
 
+// Cancel edit
 document.getElementById("cancel-btn").addEventListener("click", resetForm);
 
+// B3 — Filter table
+document.getElementById("env-search").addEventListener("input", applyFilter);
+
+// Form submit (add / update)
 document.getElementById("environment-form").addEventListener("submit", (event) => {
   event.preventDefault();
 
   const environmentId = document.getElementById("environment-id").value.trim();
   const environmentColor = document.getElementById("environment-color").value;
-  const environmentType = document.getElementById("environment-type").value;
   const environmentDesc = document.getElementById("environment-desc").value.trim();
+
+  let environmentType = document.getElementById("environment-type").value;
+  if (environmentType === "Custom") {
+    environmentType = document.getElementById("environment-type-custom").value.trim();
+    if (!environmentType) {
+      showToast("Please enter a custom environment type.", "warning");
+      document.getElementById("environment-type-custom").focus();
+      return;
+    }
+  }
 
   chrome.storage.sync.get("environments", (data) => {
     const environments = data.environments || {};
@@ -176,7 +280,9 @@ document.getElementById("environment-form").addEventListener("submit", (event) =
         }
 
         chrome.storage.local.set({ environmentIcons: icons }, () => {
+          const wasEdit = editMode;
           resetForm();
+          showToast(wasEdit ? "Environment updated." : "Environment saved.", "success");
           loadEnvironments();
         });
       });
@@ -184,4 +290,5 @@ document.getElementById("environment-form").addEventListener("submit", (event) =
   });
 });
 
+// Initial load
 loadEnvironments();

--- a/options.js
+++ b/options.js
@@ -290,5 +290,19 @@ document.getElementById("environment-form").addEventListener("submit", (event) =
   });
 });
 
+// What's New banner — show once after update, clear badge on dismiss
+chrome.storage.local.get(["showWhatsNew", "whatsNewVersion"], (data) => {
+  if (data.showWhatsNew) {
+    document.getElementById("whats-new-version").textContent = data.whatsNewVersion || "";
+    document.getElementById("whats-new").style.display = "block";
+  }
+});
+
+document.getElementById("whats-new-close").addEventListener("click", () => {
+  document.getElementById("whats-new").style.display = "none";
+  chrome.action.setBadgeText({ text: "" });
+  chrome.storage.local.remove(["showWhatsNew", "whatsNewVersion"]);
+});
+
 // Initial load
 loadEnvironments();


### PR DESCRIPTION
## Summary

Complete overhaul of the extension for version 3.0, introducing new features, UX improvements, technical fixes, and store publishing materials.

### New features
- **SVG icon per environment** — upload any SVG file as a visual identifier; icon is displayed in the banner and in the environments list
- **Edit existing environments** — pencil button in the table pre-fills the form for updating color, type, description or icon without re-entering the ID
- **Custom environment type** — free-form type name beyond the seven presets (Production, Default, Sandbox, Trial, Developer, UAT, Testing)
- **Three-section banner layout** — environment type on the left, description centered, SVG icon on the right; text color auto-calculated for contrast
- **Post-update What's New notification** — after an update, a blue badge appears on the extension icon; opening settings shows a dismissible banner listing changes; badge and banner are cleared once dismissed

### UX improvements
- **Toast notifications** replace all native `alert()` dialogs; delete confirmation uses a Bootstrap modal instead of `confirm()`
- **Live filter** above the environments table — filters by ID, type or description as you type
- **Buy Me a Coffee** button added to the settings page

### Technical fixes
- **Memory leak fix** — replaced repeated `addEventListener` calls inside `loadEnvironments()` with a single delegated listener on the table parent
- **Optimized URL monitoring** — removed `setInterval(1000)` from `content.js`; MutationObserver throttled via `requestAnimationFrame`; added `popstate` and `hashchange` listeners
- **Case-insensitive matching** — environment IDs from URLs and from storage are compared case-insensitively
- **New supported domains** — `make.powerpages.microsoft.com` and `admin.powerplatform.microsoft.com` added to `manifest.json`

### Documentation & publishing
- `README.md` rewritten in full — English and Polish, feature table, supported domains, usage guide
- `STORE_LISTING.md` — all fields required by Chrome Web Store and Microsoft Edge Add-ons (descriptions, permissions justifications, screenshot guidance, privacy policy URL)
- `PRIVACY_POLICY.md` — hosted directly in the repository; linked from store listing

## Test plan
- [ ] Load unpacked extension in `chrome://extensions` (Developer mode)
- [ ] Add an environment with a color, type and SVG icon → banner appears on make.powerapps.com
- [ ] Edit the environment via pencil button → form pre-fills, Update saves correctly
- [ ] Select "Custom…" type → custom text input appears and saves
- [ ] Type in the filter field → table rows filter live
- [ ] Delete an environment → modal appears, confirm removes it, toast confirms
- [ ] Save an environment → toast success appears, no alert()
- [ ] Simulate update by changing version and reloading → badge appears on icon, What's New banner shows in options, closing banner clears the badge
- [ ] Navigate between environments on Power Platform without page reload → banner updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNCD2dw9m2HMygXpyAY4jh